### PR TITLE
Document requirement for crabstone

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This is a REPL for assembly language.
 
+## Linux requirements
+```
+$ sudo apt-get install libcapstone-dev
+```
+
 ## Usage
 
 Install the gem:


### PR DESCRIPTION
Fix for capstone, on linux

```
Could not open library 'capstone': capstone: cannot open shared object file: No such file or directory. (LoadError)
Could not open library 'libcapstone.so': libcapstone.so: cannot open shared object file: No such file or directory.
Could not open library 'libcapstone.so.4': libcapstone.so.4: cannot open shared object file: No such file or directory.
Could not open library 'libcapstone.so.3': libcapstone.so.3: cannot open shared object file: No such file or directory
```