### PR TITLE
Handling invalid instructions

### DIFF
--- a/lib/asmrepl/repl.rb
+++ b/lib/asmrepl/repl.rb
@@ -71,7 +71,13 @@ module ASMREPL
             case cmd
             in :run
               break if text.chomp.empty?
-              binary = @assembler.assemble @parser.parse text.chomp
+              begin
+                parserResult = @parser.parse text.chomp
+              rescue
+                puts "Invalid intruction"
+                next
+              end
+              binary = @assembler.assemble parserResult
               binary.bytes.each { |byte| @buffer.putc byte }
               break
             in [:read, "cpu"]
@@ -88,6 +94,7 @@ module ASMREPL
             end
           end
         rescue Interrupt
+          puts ""
           exit 0
         end
         tracer.continue


### PR DESCRIPTION
At this point if the user enters something like _bov eax, 1__ ,which is an invalid ins, asmrepl spits out the traceback and exits abruptly. This code handles the exception raised by the parse error by discarding the text (and showing an error message) and moving to the next loop cycle.