### PR TITLE
Add racc 1.7.3 to dependencies to fix for Ruby 3.3.0

### DIFF
--- a/asmrepl.gemspec
+++ b/asmrepl.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'crabstone', '~> 4.0'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_dependency 'fisk', '~> 2.3.1'
+  s.add_dependency 'racc', '~> 1.7.3'
 end


### PR DESCRIPTION
Hi,

Looks like this package is broken on Ruby 3.3.0 because [racc was moved from a default gem to a bundled gem.](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/)

I added it to the asmrepl.gemspec file and that seemed to fix it, but I'm not a Ruby developer, so please let me know if I did this wrong :)

Thanks!